### PR TITLE
add -main to the list of things to ignore

### DIFF
--- a/src/carve/impl.clj
+++ b/src/carve/impl.clj
@@ -105,13 +105,13 @@
         (with-open [w (io/writer file)]
           (z/print-root zloc w))))))
 
-(defn ignore? [api-namespaces {:keys [:ns :export :defined-by :test :private]}]
+(defn ignore? [api-namespaces {:keys [:ns :export :defined-by :test :private :name]}]
   (or
    test
    export
    (when (contains? api-namespaces ns)
      (not private))
-   (= "-main" (some-> defined-by name))
+   (.startsWith (str name) "-")
    (= 'clojure.core/deftype defined-by)
    (= 'clojure.core/defrecord defined-by)
    (= 'clojure.core/defprotocol defined-by)

--- a/src/carve/impl.clj
+++ b/src/carve/impl.clj
@@ -111,6 +111,7 @@
    export
    (when (contains? api-namespaces ns)
      (not private))
+   (= "-main" (some-> defined-by name))
    (= 'clojure.core/deftype defined-by)
    (= 'clojure.core/defrecord defined-by)
    (= 'clojure.core/defprotocol defined-by)
@@ -187,4 +188,3 @@
                          analysis))
                 (reportize results)))
           (reportize results))))))
-

--- a/src/carve/impl.clj
+++ b/src/carve/impl.clj
@@ -129,9 +129,6 @@
             (println (str filename ":" row ":" col " " ns "/" name)))
     (prn report)))
 
-(defn removed? [removed {:keys [:from :from-var]}]
-  (contains? removed [from from-var]))
-
 (defn analyze [paths]
   (let [{:keys [:var-definitions
                 :var-usages]} (:analysis (clj-kondo/run! {:lint paths

--- a/test-resources/app/app.clj
+++ b/test-resources/app/app.clj
@@ -5,5 +5,7 @@
 (defn another-unused-function [])
 
 (defn used-function []) ;; won't be reported because used by -main
+
+(defn ignore-me [] nil)
 (defn -main []
   (used-function))

--- a/test-resources/uberscript/uberscript.clj
+++ b/test-resources/uberscript/uberscript.clj
@@ -502,6 +502,3 @@
      :bb  (java.util.UUID/randomUUID)
      :cljs (cljs.core/random-uuid)))
 (require '[medley.core :refer [index-by]]) (index-by :id [{:id 1} {:id 2}])
-
-(defn -main [& args]
-  (println "in main"))

--- a/test-resources/uberscript/uberscript.clj
+++ b/test-resources/uberscript/uberscript.clj
@@ -502,3 +502,6 @@
      :bb  (java.util.UUID/randomUUID)
      :cljs (cljs.core/random-uuid)))
 (require '[medley.core :refer [index-by]]) (index-by :id [{:id 1} {:id 2}])
+
+(defn -main [& args]
+  (println "in main"))

--- a/test-resources/uberscript/uberscript_carved.clj
+++ b/test-resources/uberscript/uberscript_carved.clj
@@ -14,3 +14,6 @@
   (persistent! (reduce #(assoc! %1 (f %2) %2) (transient {}) coll)))
 
 (require '[medley.core :refer [index-by]]) (index-by :id [{:id 1} {:id 2}])
+
+(defn -main [& args]
+  (println "in main"))

--- a/test-resources/uberscript/uberscript_carved.clj
+++ b/test-resources/uberscript/uberscript_carved.clj
@@ -14,6 +14,3 @@
   (persistent! (reduce #(assoc! %1 (f %2) %2) (transient {}) coll)))
 
 (require '[medley.core :refer [index-by]]) (index-by :id [{:id 1} {:id 2}])
-
-(defn -main [& args]
-  (println "in main"))

--- a/test/carve/impl_test.clj
+++ b/test/carve/impl_test.clj
@@ -9,7 +9,7 @@
              {:filename "test-resources/app/app.clj", :row 4, :col 1, :ns app, :name unused-function}
              {:filename "test-resources/app/app.clj", :row 5, :col 1, :ns app, :name another-unused-function})
            (impl/run! {:paths [(.getPath (io/file "test-resources" "app"))]
-                       :ignore-vars ['app/-main] :api-namespaces ['api] :report true}))))
+                       :ignore-vars ['app/-main 'app/ignore-me] :api-namespaces ['api] :report true}))))
   (testing "with aggressive"
     (= '[{:filename "test-resources/app/app.clj", :row 4, :col 1, :ns app, :name unused-function}
          {:filename "test-resources/app/app.clj", :row 5, :col 1, :ns app, :name another-unused-function}

--- a/test/carve/main_test.clj
+++ b/test/carve/main_test.clj
@@ -38,11 +38,21 @@
                    :report {:format :text}})
         "-main"))))
 
+(deftest ignore-var-test
+  (is (false?
+       (clojure.string/includes?
+        (run-main {:paths [(.getPath (io/file "test-resources" "app"))]
+                   :api-namespaces ['api]
+                   :ignore-vars ['app/ignore-me]
+                   :report {:format :text}})
+        "-ignore-me"))))
+
 (deftest text-report-test
   (is (= (str/trim "
 test-resources/app/api.clj:3:1 api/private-lib-function
 test-resources/app/app.clj:4:1 app/unused-function
-test-resources/app/app.clj:5:1 app/another-unused-function")
+test-resources/app/app.clj:5:1 app/another-unused-function
+test-resources/app/app.clj:9:1 app/ignore-me")
          (str/trim (run-main {:paths [(.getPath (io/file "test-resources" "app"))]
                               :api-namespaces ['api]
                               :report {:format :text}})))))

--- a/test/carve/main_test.clj
+++ b/test/carve/main_test.clj
@@ -5,27 +5,28 @@
    [clojure.string :as str]
    [clojure.java.io :as io]))
 
+(defn- run-main [opts]
+  (with-out-str
+    (main/-main "--opts" (str opts))))
+
 (deftest carve-test
   (let [uberscript (.getPath (io/file "test-resources" "uberscript" "uberscript.clj"))
         uberscript-carved-expected (.getPath (io/file "test-resources" "uberscript" "uberscript_carved.clj"))
         tmp-dir (System/getProperty "java.io.tmpdir")
         uberscript-carved (io/file tmp-dir "test-resources" "uberscript" "uberscript.clj")]
-    (with-out-str
-      (main/-main "--opts" (str {:paths [uberscript]
-                                 :aggressive? true
-                                 :interactive? false
-                                 :out-dir tmp-dir})))
+    (run-main {:paths [uberscript]
+               :aggressive? true
+               :interactive? false
+               :out-dir tmp-dir})
     (is (= (slurp uberscript-carved-expected)
            (slurp uberscript-carved)))))
 
 (deftest issue-11-test
   (let [tmp-dir (System/getProperty "java.io.tmpdir")]
-    (with-out-str
-      (main/-main "--opts"
-                  (str {:paths [(.getPath (io/file "test-resources" "issue_11"))]
+    (run-main {:paths [(.getPath (io/file "test-resources" "issue_11"))]
                         :aggressive? true
                         :interactive? false
-                        :out-dir tmp-dir})))
+               :out-dir tmp-dir})
     (is (= (slurp (io/file "test-resources" "issue_11" "issue_11_expected.clj"))
            (slurp (io/file tmp-dir "test-resources" "issue_11" "issue_11.clj"))))))
 
@@ -34,20 +35,18 @@
 test-resources/app/api.clj:3:1 api/private-lib-function
 test-resources/app/app.clj:4:1 app/unused-function
 test-resources/app/app.clj:5:1 app/another-unused-function")
-         (str/trim (with-out-str
-                     (main/-main "--opts"
-                                 (str {:paths [(.getPath (io/file "test-resources" "app"))]
-                                       :ignore-vars ['app/-main]
-                                       :api-namespaces ['api]
-                                       :report {:format :text}})))))))
+         (str/trim (run-main {:paths [(.getPath (io/file "test-resources" "app"))]
+                              :ignore-vars ['app/-main]
+                              :api-namespaces ['api]
+                              :report {:format :text}})))))
 
 (deftest options-validation-test
   (testing "Forgetting to quote paths give an error"
     (is (thrown? clojure.lang.ExceptionInfo
-                 (main/-main "--opts" "{:paths [src test]}"))))
+                 (run-main "{:paths [src test]}"))))
 
   (testing "Passing a non existing directory fails to validate"
     (is (thrown-with-msg?
          clojure.lang.ExceptionInfo
          #"Path not found"
-         (main/-main "--opts" (str {:paths ["not-existing"]}))))))
+         (run-main {:paths ["not-existing"]})))))

--- a/test/carve/main_test.clj
+++ b/test/carve/main_test.clj
@@ -30,13 +30,20 @@
     (is (= (slurp (io/file "test-resources" "issue_11" "issue_11_expected.clj"))
            (slurp (io/file tmp-dir "test-resources" "issue_11" "issue_11.clj"))))))
 
+(deftest ignore-main-test
+  (is (false?
+       (clojure.string/includes?
+        (run-main {:paths [(.getPath (io/file "test-resources" "app"))]
+                   :api-namespaces ['api]
+                   :report {:format :text}})
+        "-main"))))
+
 (deftest text-report-test
   (is (= (str/trim "
 test-resources/app/api.clj:3:1 api/private-lib-function
 test-resources/app/app.clj:4:1 app/unused-function
 test-resources/app/app.clj:5:1 app/another-unused-function")
          (str/trim (run-main {:paths [(.getPath (io/file "test-resources" "app"))]
-                              :ignore-vars ['app/-main]
                               :api-namespaces ['api]
                               :report {:format :text}})))))
 


### PR DESCRIPTION
Since there are other methods that start with `-` which we might want to ignore as well, this PR simply ignores everything starting with `-`, which will include `-main`.

I also did a small refactor to make it slightly easier to call the main in main_test.