### PR TITLE
exit with status code 1 when the report is not empty

### DIFF
--- a/src/carve/main.clj
+++ b/src/carve/main.clj
@@ -43,12 +43,18 @@
   (when-not (every? valid-path? paths)
     (throw (ex-info "Path not found" {:paths paths}))))
 
-(defn -main [& [flag opts & _args]]
+(defn main
+  [& [flag opts & _args]]
   (when-not (= "--opts" flag)
     (throw (ex-info (str "Unrecognized option: " flag) {:flag flag})))
   (let [opts (edn/read-string opts)
         _ (validate-opts! opts)
+        format (-> opts :report :format)
         report (impl/run! opts)]
-    (when-let [r (:report opts)]
-      (let [format (:format r)]
-        (impl/print-report report format)))))
+    (when format
+      (impl/print-report report format))
+    (if (empty? report) 0 1)))
+
+(defn -main
+  [& options]
+  (System/exit (apply main options)))

--- a/test-resources/unchanged.clj
+++ b/test-resources/unchanged.clj
@@ -1,0 +1,9 @@
+(ns unchanged)
+
+(defn func
+  []
+  42)
+
+(defn -main
+  [& args]
+  (func))

--- a/test/carve/main_test.clj
+++ b/test/carve/main_test.clj
@@ -9,7 +9,7 @@
 
 (defn- run-main [opts]
   (with-out-str
-    (main/-main "--opts" (str opts))))
+    (main/main "--opts" (str opts))))
 
 (deftest carve-test
   (let [uberscript (.getPath (io/file "test-resources" "uberscript" "uberscript.clj"))
@@ -58,6 +58,18 @@ test-resources/app/app.clj:9:1 app/ignore-me")
          (str/trim (run-main {:paths [(.getPath (io/file "test-resources" "app"))]
                               :api-namespaces ['api]
                               :report {:format :text}})))))
+
+(deftest report-exit-code-test
+  (testing "Nothing to report exits with exit code 0"
+    (is (= 0 (main/main "--opts" (str {:paths [(.getPath (io/file "test-resources" "unchanged.clj"))]
+                                       :api-namespaces ['api]
+                                       :report {:format :text}})))))
+
+  (testing "Something to report exits with exit code 1"
+    (is (= 1
+           (main/main "--opts" (str {:paths [(.getPath (io/file "test-resources" "app"))]
+                                     :api-namespaces ['api]
+                                     :report {:format :text}}))))))
 
 (deftest options-validation-test
   (testing "Forgetting to quote paths give an error"


### PR DESCRIPTION
This is particularly useful for things like CI where having some dead
code is supposed to make the build fail.