### PR TITLE
Add instructions to run tests with cider

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,1 +1,0 @@
-((clojure-mode . ((cider-clojure-cli-global-options . "-R:test"))))

--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,1 @@
+((clojure-mode . ((cider-clojure-cli-global-options . "-R:test"))))

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.cpcache
 /target/
+.dir-locals.el

--- a/README.md
+++ b/README.md
@@ -130,7 +130,15 @@ If the `report` step finds any dead code it exits with status code `1`, thus fai
 
 ### Emacs
 
-In Emacs you might want to invoke carve using the `:report` option in `eshell`. When you enable `compilation-minor-mode` the links become clickable.
+Running carve with in report mode (for example `clojure -Acarve --opts '{:paths ["src" "test"] :report {:format :text}}'`)
+you can make all the links clickable by switching to compilation-mode.
+
+If you want to run tests in Emacs and Cider you need to use the test alias, or it will fail while trying to load the `test.check` library.
+Just place this in your `.dir-locals.el` file in the root directory to always use the test alias:
+
+```elisp
+((clojure-mode . ((cider-clojure-cli-global-options . "-R:test"))))
+```
 
 <img src="assets/eshell.png">
 


### PR DESCRIPTION
Set a cider option in dir-locals to set the right alias for the repl.

Without this alias the test.check library can't be found since it's
only in the test alias extra dependencies.