### PR TITLE
fix: drop unused ->arrow-fns

### DIFF
--- a/src/carve/impl.clj
+++ b/src/carve/impl.clj
@@ -118,15 +118,15 @@
 
 (defn ignore? [api-namespaces {:keys [:ns :export :defined-by :test :private :name]}]
   (or
-   test
-   export
-   (when (contains? api-namespaces ns)
-     (not private))
-   (.startsWith (str name) "-")
-   (= 'clojure.core/deftype defined-by)
-   (= 'clojure.core/defrecord defined-by)
-   (= 'clojure.core/defprotocol defined-by)
-   (= 'clojure.core/definterface defined-by)))
+    test
+    export
+    (when (contains? api-namespaces ns)
+      (not private))
+    (= (str name) "-main")
+    (= 'clojure.core/deftype defined-by)
+    (= 'clojure.core/defrecord defined-by)
+    (= 'clojure.core/defprotocol defined-by)
+    (= 'clojure.core/definterface defined-by)))
 
 (defn reportize [results]
   (sort-by (juxt :filename :row :col)

--- a/test-resources/app/app.clj
+++ b/test-resources/app/app.clj
@@ -7,5 +7,8 @@
 (defn used-function []) ;; won't be reported because used by -main
 
 (defn ignore-me [] nil)
+
+(defn ->unused-arrow-fn [] nil) ;; should be reported despite leading `-`
+
 (defn -main []
   (used-function))

--- a/test/carve/impl_test.clj
+++ b/test/carve/impl_test.clj
@@ -19,16 +19,22 @@
                :row      5
                :col      1
                :ns       app
-               :name     another-unused-function}}
+               :name     another-unused-function}
+              {:filename "test-resources/app/app.clj"
+               :row      11
+               :col      1
+               :ns       app
+               :name     ->unused-arrow-fn}
+              }
            (set (impl/run! {:paths       [(.getPath (io/file "test-resources" "app"))]
                             :ignore-vars ['app/-main 'app/ignore-me] :api-namespaces ['api] :report true})))))
 
   (testing "with aggressive"
     (is (= '#{{:filename "test-resources/app/api.clj",
-                :row      3,
-                :col      1,
-                :ns       api,
-                :name     private-lib-function}
+               :row      3,
+               :col      1,
+               :ns       api,
+               :name     private-lib-function}
               {:filename "test-resources/app/app.clj",
                :row      4,
                :col      1,
@@ -45,10 +51,16 @@
                :ns       app,
                :name     ignore-me}
               {:filename "test-resources/app/app.clj",
-               :row 3,
-               :col 1,
-               :ns app,
-               :name only-used-by-unused-function}}
+               :row      3,
+               :col      1,
+               :ns       app,
+               :name     only-used-by-unused-function}
+              {:filename "test-resources/app/app.clj"
+               :row      11
+               :col      1
+               :ns       app
+               :name     ->unused-arrow-fn}
+              }
 
            (set (impl/run! {:paths       [(.getPath (io/file "test-resources" "app"))]
                             :ignore-vars ['app/-main] :api-namespaces ['api] :report true :aggressive true}))))))

--- a/test/carve/main_test.clj
+++ b/test/carve/main_test.clj
@@ -38,30 +38,39 @@
 
 (deftest ignore-main-test
   (is (false?
-       (clojure.string/includes?
-        (run-main {:paths [(.getPath (io/file "test-resources" "app"))]
+        (clojure.string/includes?
+          (run-main {:paths          [(.getPath (io/file "test-resources" "app"))]
+                     :api-namespaces ['api]
+                     :report         {:format :text}})
+          "-main"))))
+
+(deftest unused-arrow-fn-names-test
+  (is (clojure.string/includes?
+        (run-main {:paths          [(.getPath (io/file "test-resources" "app"))]
                    :api-namespaces ['api]
-                   :report {:format :text}})
-        "-main"))))
+                   :report         {:format :text}})
+        "->unused-arrow-fn")))
 
 (deftest ignore-var-test
   (is (false?
-       (clojure.string/includes?
-        (run-main {:paths [(.getPath (io/file "test-resources" "app"))]
-                   :api-namespaces ['api]
-                   :ignore-vars ['app/ignore-me]
-                   :report {:format :text}})
-        "-ignore-me"))))
+        (clojure.string/includes?
+          (run-main {:paths          [(.getPath (io/file "test-resources" "app"))]
+                     :api-namespaces ['api]
+                     :ignore-vars    ['app/ignore-me]
+                     :report         {:format :text}})
+          "-ignore-me"))))
 
 (deftest text-report-test
   (is (= (str/trim "
 test-resources/app/api.clj:3:1 api/private-lib-function
 test-resources/app/app.clj:4:1 app/unused-function
 test-resources/app/app.clj:5:1 app/another-unused-function
-test-resources/app/app.clj:9:1 app/ignore-me")
-         (str/trim (run-main {:paths [(.getPath (io/file "test-resources" "app"))]
+test-resources/app/app.clj:9:1 app/ignore-me
+test-resources/app/app.clj:11:1 app/->unused-arrow-fn
+")
+         (str/trim (run-main {:paths          [(.getPath (io/file "test-resources" "app"))]
                               :api-namespaces ['api]
-                              :report {:format :text}})))))
+                              :report         {:format :text}})))))
 
 (deftest report-exit-code-test
   (testing "Nothing to report exits with exit code 0"


### PR DESCRIPTION
The fix to prevent carve from clearing `-main` fns has the side-effect
of clearing `->` prefixed arrow functions, which is probably unintended.

This fix extends the `-` filter to dodge `->` prefixes:

``` clojure
(and (.startsWith (str name) "-")
     (not (.startsWith (str name) "->")))
```

I'm not sure of any other `-` leading prefixes to keep, so this seems
fine for now. Includes test updates.

Let me know if you'd rather test or filter these any differently - happy to do so.

Also, my editor's aggressive indent over-reached in a few places - i can go through and restore the original lines in places if you'd prefer.