### PR TITLE
feat: optionally ignore comment usages

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ expects an EDN map of the following options of which only `:paths` is required:
   can be `:edn` or `:text`. The text output can be interpreted by editors like
   Emacs. This option can be combined with `:aggressive`.
 - `:silent`: when truthy, does not write to stdout. Implies `:interactive false`.
+- `:clj-kondo/config`: a map of clj-kondo config opts that are passed on to
+  clj-kondo, which is used to analyze usages. e.g.: passing `{:skip-comments
+  true}` will ignore function usage in `(comment)` forms. Note that the config
+  in `.clj-kondo/config.edn` is used as well - options passed with this key will
+  override options set in the clj-kondo config file.
 
 ``` shell
 $ clojure -M:carve --opts '{:paths ["test-resources"] :dry-run true}'

--- a/test-resources/app/app.clj
+++ b/test-resources/app/app.clj
@@ -10,5 +10,10 @@
 
 (defn ->unused-arrow-fn [] nil) ;; should be reported despite leading `-`
 
+(defn only-used-in-comment [] nil) ;; reported if :skip-comments is truthy
+
+(comment
+  (only-used-in-comment))
+
 (defn -main []
   (used-function))

--- a/test/carve/impl_test.clj
+++ b/test/carve/impl_test.clj
@@ -24,8 +24,7 @@
                :row      11
                :col      1
                :ns       app
-               :name     ->unused-arrow-fn}
-              }
+               :name     ->unused-arrow-fn}}
            (set (impl/run! {:paths       [(.getPath (io/file "test-resources" "app"))]
                             :ignore-vars ['app/-main 'app/ignore-me] :api-namespaces ['api] :report true})))))
 
@@ -63,4 +62,35 @@
               }
 
            (set (impl/run! {:paths       [(.getPath (io/file "test-resources" "app"))]
-                            :ignore-vars ['app/-main] :api-namespaces ['api] :report true :aggressive true}))))))
+                            :ignore-vars ['app/-main] :api-namespaces ['api] :report true :aggressive true})))))
+
+  (testing "without aggressive, but skip comment usages"
+    (is (= '#{{:filename "test-resources/app/api.clj"
+               :row      3
+               :col      1
+               :ns       api
+               :name     private-lib-function}
+              {:filename "test-resources/app/app.clj"
+               :row      4
+               :col      1
+               :ns       app
+               :name     unused-function}
+              {:filename "test-resources/app/app.clj"
+               :row      5
+               :col      1
+               :ns       app
+               :name     another-unused-function}
+              {:filename "test-resources/app/app.clj"
+               :row      11
+               :col      1
+               :ns       app
+               :name     ->unused-arrow-fn}
+              {:filename "test-resources/app/app.clj"
+               :row      13
+               :col      1
+               :ns       app
+               :name     only-used-in-comment}}
+           (set (impl/run! {:paths            [(.getPath (io/file "test-resources" "app"))]
+                            :clj-kondo/config {:skip-comments true}
+                            :ignore-vars      ['app/-main 'app/ignore-me]
+                            :api-namespaces   ['api] :report true}))))))

--- a/test/carve/main_test.clj
+++ b/test/carve/main_test.clj
@@ -96,6 +96,15 @@ test-resources/app/app.clj:11:1 app/->unused-arrow-fn
 
   (testing "Passing a non existing directory fails to validate"
     (is (thrown-with-msg?
-         clojure.lang.ExceptionInfo
-         #"Path not found"
-         (run-main {:paths ["not-existing"]})))))
+          clojure.lang.ExceptionInfo
+          #"Path not found"
+          (run-main {:paths ["not-existing"]})))))
+
+(deftest comment-only-usage-test
+  (testing "tests reporting/removal of functions only used in comment"
+    (is (clojure.string/includes?
+          (run-main {:paths            [(.getPath (io/file "test-resources" "app"))]
+                     :api-namespaces   ['api]
+                     :clj-kondo/config {:skip-comments true}
+                     :report           {:format :text}})
+          "only-used-in-comment"))))


### PR DESCRIPTION
Thanks much for carve! I'm enjoying squeezing performance out of some babashka
scripts with it. My use-case right now is building uberscripts from a more
feature-full environment and then `carving` them down to the minimum,
and it's working well.

I like to leave comments as siblings to functions fairly often, but found that
this was preventing carve from removing otherwise unused functions. Another way
of solving this might be just dropping/ignoring comments when creating
uberscripts in the first place...

When digging I found clj-kondo was finding the usages, and already supports
:skip-comments. Thanks for making this easy :)

This PR adds a :skip-comments option, which is passed through to clj-kondo's
`analyze`, so that comment usage is ignored and those functions are removed from
the uberscript. Another option for naming might be `:skip-comment-usages`.

I had originally hoped to clean up the comments for users after the fact, or
maybe just prefixing a `#_(comment ...)` in front of the form, but I'm not sure
what's best to do there. As written, the user will be left with a handful of
comments with non-existent functions in them, which clj-kondo calls out
immediately. Otherwise the code still runs, so it's not too bad.