### PR TITLE
Report/Remove unused referred vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ Keep in mind that if you ran `carve` with `'{:paths ["src" "test"]}'`, there mig
 So after a first cycle of carving you might want to do another run with simply `{:paths ["src"]}`, which will help deleting the rest of the unused code.
 *Just beware that this will break all the tests using the code you just deleted, and you'll have to fix/delete them manually.**
 
+Carve also removes any unused refers from namespace `:require` forms. This means
+_any_ unused refer, not just refers for functions determined to be unused by
+carve.
+
 ### CI integration
 
 A good use case for Carve is the CI integration, to ensure that no one can introduce dead code into a codebase.

--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,5 @@
 {:deps {clj-kondo/clj-kondo {:git/url "https://github.com/borkdude/clj-kondo"
-                   :sha "f4941cb3f2a1e643413dde11a7b09f24087b7afc"}
+                             :sha "f5c8639276b0c97e674a9b40435d4cccd985942d"}
         borkdude/rewrite-cljc {:git/url "https://github.com/borkdude/rewrite-cljc-playground"
                                :sha "a60f2d3b172c6a8f1c25875f2af6c964b3f5fcc0"}
         expound/expound {:mvn/version "0.8.6"}}

--- a/src/carve/impl.clj
+++ b/src/carve/impl.clj
@@ -195,15 +195,14 @@
             unused-vars (set/difference (set defined-vars) used-vars)
             unused-vars-data (map definitions-by-ns+name unused-vars)
             unused-vars-data (remove #(ignore? api-namespaces %) unused-vars-data)
-
-            ;; append unused-var-refers for removal
-            unused-vars-data (concat unused-vars-data unused-var-refers)
             ;; update unused-vars with ignored ones (deftest, etc)
             unused-vars (set (map (juxt :ns :name) unused-vars-data))
             results (into results unused-vars-data)]
-        (if (seq unused-vars-data)
+        (if (or (seq unused-vars-data) (seq unused-var-refers))
           (do (when-not (:report opts)
-                (let [data-by-file (group-by :filename unused-vars-data)]
+                (let [data-by-file (->> unused-vars-data
+                                        (concat unused-var-refers)
+                                        (group-by :filename))]
                   (doseq [[file vs] data-by-file]
                     (carve! file vs opts))))
               (if aggressive

--- a/test-resources/app/app.clj
+++ b/test-resources/app/app.clj
@@ -1,4 +1,4 @@
-(ns app)
+(ns app (:require [clojure.string :refer [split]]))
 
 (defn only-used-by-unused-function []) ;; only reported with aggressive?
 (defn unused-function [] (only-used-by-unused-function))

--- a/test-resources/remove_refers/uberscript.clj
+++ b/test-resources/remove_refers/uberscript.clj
@@ -1,0 +1,14 @@
+(ns app.command)
+
+(defn unused-fn [] nil)
+
+(defn used-fn [] (prn "used-fn called"))
+
+(ns app.cli
+  (:require
+   [app.command :refer [used-fn unused-fn]]))
+
+(defn -main [& _args]
+  (used-fn))
+
+(ns user (:require [app.cli])) (apply app.cli/-main *command-line-args*)

--- a/test-resources/remove_refers/uberscript_expected.clj
+++ b/test-resources/remove_refers/uberscript_expected.clj
@@ -1,0 +1,12 @@
+(ns app.command)
+
+(defn used-fn [] (prn "used-fn called"))
+
+(ns app.cli
+  (:require
+   [app.command :refer [used-fn]]))
+
+(defn -main [& _args]
+  (used-fn))
+
+(ns user (:require [app.cli])) (apply app.cli/-main *command-line-args*)

--- a/test-resources/remove_refers/uberscript_two.clj
+++ b/test-resources/remove_refers/uberscript_two.clj
@@ -1,0 +1,22 @@
+(ns app.command)
+
+(defn unused-fn [] nil)
+
+(defn used-fn [] (prn "used-fn called"))
+
+(ns app.another-ns
+  (:require
+   [app.command :refer [unused-fn]]))
+
+(defn another-used-fn [] (prn "another-used-fn called"))
+
+(ns app.cli
+  (:require
+   [app.another-ns :refer [another-used-fn]]
+   [app.command :refer [used-fn unused-fn]]))
+
+(defn -main [& _args]
+  (another-used-fn)
+  (used-fn))
+
+(ns user (:require [app.cli])) (apply app.cli/-main *command-line-args*)

--- a/test-resources/remove_refers/uberscript_two_expected.clj
+++ b/test-resources/remove_refers/uberscript_two_expected.clj
@@ -1,0 +1,20 @@
+(ns app.command)
+
+(defn used-fn [] (prn "used-fn called"))
+
+(ns app.another-ns
+  (:require
+   [app.command :refer []]))
+
+(defn another-used-fn [] (prn "another-used-fn called"))
+
+(ns app.cli
+  (:require
+   [app.another-ns :refer [another-used-fn]]
+   [app.command :refer [used-fn]]))
+
+(defn -main [& _args]
+  (another-used-fn)
+  (used-fn))
+
+(ns user (:require [app.cli])) (apply app.cli/-main *command-line-args*)

--- a/test/carve/impl_test.clj
+++ b/test/carve/impl_test.clj
@@ -24,9 +24,16 @@
                :row      11
                :col      1
                :ns       app
-               :name     ->unused-arrow-fn}}
-           (set (impl/run! {:paths       [(.getPath (io/file "test-resources" "app"))]
-                            :ignore-vars ['app/-main 'app/ignore-me] :api-namespaces ['api] :report true})))))
+               :name     ->unused-arrow-fn}
+              {:filename "test-resources/app/app.clj"
+               :row      1
+               :col      43
+               :ns       clojure.string
+               :name     split}}
+           (set (impl/run! {:paths          [(.getPath (io/file "test-resources" "app"))]
+                            :ignore-vars    ['app/-main 'app/ignore-me]
+                            :api-namespaces ['api]
+                            :report         true})))))
 
   (testing "with aggressive"
     (is (= '#{{:filename "test-resources/app/api.clj",
@@ -59,6 +66,12 @@
                :col      1
                :ns       app
                :name     ->unused-arrow-fn}
+              {:filename "test-resources/app/app.clj"
+               :row      1
+               :col      43
+               :ns       clojure.string
+               :name     split
+               }
               }
 
            (set (impl/run! {:paths       [(.getPath (io/file "test-resources" "app"))]
@@ -89,7 +102,12 @@
                :row      13
                :col      1
                :ns       app
-               :name     only-used-in-comment}}
+               :name     only-used-in-comment}
+              {:filename "test-resources/app/app.clj"
+               :row      1
+               :col      43
+               :ns       clojure.string
+               :name     split}}
            (set (impl/run! {:paths            [(.getPath (io/file "test-resources" "app"))]
                             :clj-kondo/config {:skip-comments true}
                             :ignore-vars      ['app/-main 'app/ignore-me]

--- a/test/carve/impl_test.clj
+++ b/test/carve/impl_test.clj
@@ -24,12 +24,7 @@
                :row      11
                :col      1
                :ns       app
-               :name     ->unused-arrow-fn}
-              {:filename "test-resources/app/app.clj"
-               :row      1
-               :col      43
-               :ns       clojure.string
-               :name     split}}
+               :name     ->unused-arrow-fn}}
            (set (impl/run! {:paths          [(.getPath (io/file "test-resources" "app"))]
                             :ignore-vars    ['app/-main 'app/ignore-me]
                             :api-namespaces ['api]
@@ -65,14 +60,7 @@
                :row      11
                :col      1
                :ns       app
-               :name     ->unused-arrow-fn}
-              {:filename "test-resources/app/app.clj"
-               :row      1
-               :col      43
-               :ns       clojure.string
-               :name     split
-               }
-              }
+               :name     ->unused-arrow-fn}}
 
            (set (impl/run! {:paths       [(.getPath (io/file "test-resources" "app"))]
                             :ignore-vars ['app/-main] :api-namespaces ['api] :report true :aggressive true})))))
@@ -102,12 +90,7 @@
                :row      13
                :col      1
                :ns       app
-               :name     only-used-in-comment}
-              {:filename "test-resources/app/app.clj"
-               :row      1
-               :col      43
-               :ns       clojure.string
-               :name     split}}
+               :name     only-used-in-comment}}
            (set (impl/run! {:paths            [(.getPath (io/file "test-resources" "app"))]
                             :clj-kondo/config {:skip-comments true}
                             :ignore-vars      ['app/-main 'app/ignore-me]

--- a/test/carve/main_test.clj
+++ b/test/carve/main_test.clj
@@ -88,7 +88,6 @@
   (is (=
         (-> (str/trim "
 test-resources/app/api.clj:3:1 api/private-lib-function
-test-resources/app/app.clj:1:43 clojure.string/split
 test-resources/app/app.clj:4:1 app/unused-function
 test-resources/app/app.clj:5:1 app/another-unused-function
 test-resources/app/app.clj:9:1 app/ignore-me


### PR DESCRIPTION
Updates carve to remove any unused-refers, as determined by clj-kondo's
:findings report.

I could see the default for this going either way, but decided to lean toward
always removing the references, at least when unused functions are already being
removed. Maybe there is a counter-case - if so, I'm happy to move this behind a
feature flag, or at least provide one if it is useful.

The big win here is that carving can sometimes remove functions without removing
the relevant :refers, which prevents the result from being runnable without
fixing the refers by hand. With this fix, you can build, carve, and run an
uberscript all in one go.

Includes an update to the clj-kondo :sha, so that the findings report includes
the name and namespace of the unused-ref. This is to support showing the vars in
the printed report, but was not strictly necessary for the physical removal.
