### PR TITLE
feat: better interactive refer-removal message

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,5 @@
 {:deps {clj-kondo/clj-kondo {:git/url "https://github.com/borkdude/clj-kondo"
-                             :sha "f5c8639276b0c97e674a9b40435d4cccd985942d"}
+                             :sha "3f842a99eb6da64b3ca6e952ddb7f00278e36c87"}
         borkdude/rewrite-cljc {:git/url "https://github.com/borkdude/rewrite-cljc-playground"
                                :sha "a60f2d3b172c6a8f1c25875f2af6c964b3f5fcc0"}
         expound/expound {:mvn/version "0.8.6"}}

--- a/test-resources/interactive/leave_function.clj
+++ b/test-resources/interactive/leave_function.clj
@@ -1,0 +1,9 @@
+(ns interactive.leave-function
+  (:require [clojure.string :refer [split]]))
+
+(defn used-fn [] nil)
+
+(defn unused-fn [] nil)
+
+(fn -main [& _args]
+  (used-fn))

--- a/test-resources/interactive/leave_function_expected.clj
+++ b/test-resources/interactive/leave_function_expected.clj
@@ -1,0 +1,9 @@
+(ns interactive.leave-function
+  (:require [clojure.string :refer []]))
+
+(defn used-fn [] nil)
+
+(defn unused-fn [] nil)
+
+(fn -main [& _args]
+  (used-fn))

--- a/test-resources/interactive/remove_all.clj
+++ b/test-resources/interactive/remove_all.clj
@@ -1,0 +1,9 @@
+(ns interactive.remove-all
+  (:require [clojure.string :refer [split]]))
+
+(defn used-fn [] nil)
+
+(defn unused-fn [] nil)
+
+(fn -main [& _args]
+  (used-fn))

--- a/test-resources/interactive/remove_all_expected.clj
+++ b/test-resources/interactive/remove_all_expected.clj
@@ -1,0 +1,7 @@
+(ns interactive.remove-all
+  (:require [clojure.string :refer []]))
+
+(defn used-fn [] nil)
+
+(fn -main [& _args]
+  (used-fn))


### PR DESCRIPTION
Updates the clj-kondo dep to the latest, to be sure refer-removal runs
smoothly without the included ns and name in clj-kondo's findings.

The context presented during interactive mode for refers was weak - only
showing the name of the var, no namespace or surrounding lines. This
commit lifts babashka's error-context function and uses it as a
fallback for presenting context when the symbol at the location is not
known. I'm hopeful this fallback to surrouding lines will be immediately
applicable if more use-cases popup (using other clj-kondo findings, for
example.)

The interact function has been extended to prevent suggesting/adding a
nil symbol to the carve_ignore.