### PR TITLE
avoid merging configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,9 @@ clojure -M:carve --opts '{:paths ["src" "test"]}'
 on the JVM.
 
 You can also store the config for your project in `.carve/config.edn`. When
-invoking carve with no options, the options in `.carve/config.edn` will be
-used. When providing options, the CLI options will be merged into those provided
-in `.carve/config.edn`.
+invoking carve with no options, the options in `.carve/config.edn` will be used.
+When providing options, the CLI options will take precedence over the configuration
+in`.carve/config.edn`.
 
 Currently `carve` only has one command line option, `--opts`, which expects an
 EDN map or EDN file with the following options of which only `:paths` is

--- a/src/carve/main.clj
+++ b/src/carve/main.clj
@@ -52,17 +52,12 @@
   (when-not (every? valid-path? paths)
     (throw (ex-info "Path not found" {:paths paths}))))
 
-(defn merger [a b]
-  (if (coll? a)
-    (into a b)
-    b))
-
 (defn- load-opts
+  "Load options, giving higher precedence to options passed from the CLI"
   [config opts]
-  (let [opts (if (and opts (valid-path? opts))
-               (slurp opts) opts)
-        opts (edn/read-string opts)
-        opts (merge-with merger config opts)]
+  (let [opts (if opts
+               (edn/read-string opts)
+               config)]
     (validate-opts! opts)
     opts))
 

--- a/test/carve/main_test.clj
+++ b/test/carve/main_test.clj
@@ -170,3 +170,9 @@ test-resources/app/app.clj:11:1 app/->unused-arrow-fn
 ------------------
 1: (ns app (:require [clojure.string :refer [split]]))
                                              ^--- unused var")))))
+
+(deftest load-config-test
+  (testing "passing arguments from the cli overrides the configuration"
+    (is (= {:paths ["src"]}
+           (#'main/load-opts {:paths ["src" "test"]}
+                             "{:paths [\"src\"]}")))))


### PR DESCRIPTION
The configuration passed in from the CLI should simply override whatever was set in carve/config.edn instead of trying to merge it partially.
Closes #42 