### PR TITLE
fix invoking carve with no options

### DIFF
--- a/src/carve/main.clj
+++ b/src/carve/main.clj
@@ -6,7 +6,7 @@
 
 (defn main
   [& [flag opts & _args]]
-  (when (not (= "--opts" flag))
+  (when (and (some? flag) (not (= "--opts" flag)))
     (throw (ex-info (str "Unrecognized option: " flag) {:flag flag})))
   (let [opts (if opts (edn/read-string opts) nil)]
     (:exit-code (api/carve! opts))))


### PR DESCRIPTION
Previously you'd need to call `carve --opts`
in order for carve to use `.carve/config.edn`.
With this commit, you can instead just call `carve`.