### PR TITLE
[Feature] Delete empty files

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ All options:
 - `:ignore-vars`: a list of vars to ignore. Useful for when the analyzer has it wrong or you just want to keep the var for whatever reason.
 - `:api-namespaces`: a list of namespaces of which only unused private vars will
   be reported.
+- `:rm-empty-namespaces`: when truthy, also deletes files considered empty, i.e.
+  those files in which there is no non-whitespace/non-comment content other than
+  the namespace declaration
 - `:carve-ignore-file`: a file where ignored vars can be stored, `.carve/ignore`
   by default.
 - `:interactive`: ask what to do with an unused var: remove from the file, add

--- a/README.md
+++ b/README.md
@@ -100,14 +100,14 @@ All options:
 - `:ignore-vars`: a list of vars to ignore. Useful for when the analyzer has it wrong or you just want to keep the var for whatever reason.
 - `:api-namespaces`: a list of namespaces of which only unused private vars will
   be reported.
-- `:rm-empty-namespaces`: when truthy, also deletes files considered empty, i.e.
-  those files in which there is no non-whitespace/non-comment content other than
-  the namespace declaration
 - `:carve-ignore-file`: a file where ignored vars can be stored, `.carve/ignore`
   by default.
 - `:interactive`: ask what to do with an unused var: remove from the file, add
   to `.carve/ignore` or continue. Set to `true` by default.
 - `:out-dir`: instead of writing back to the original file, write to this dir.
+- `:delete-empty-files`: when truthy, also deletes files considered empty,
+  i.e. those files that have no non-whitespace/non-comment content other than
+  namespace declaration. Only does this to files with carved vars.
 - `:dry-run`: just print the unused var expression.
 - `:aggressive`: runs multiple times until no unused vars are left. Defaults to `false`.
 - `:report`: when truthy, prints unused vars to stdout. Implies `:dry-run

--- a/src/carve/api.clj
+++ b/src/carve/api.clj
@@ -28,12 +28,12 @@
    {:paths {:coerce [] :desc "A list of paths to analyze (files and dirs)"}
     :ignore-vars {:coerce [:symbol] :desc "A list of vars to ignore"}
     :api-namespaces {:coerce [:symbol] :desc "A list of namespaces to ignore"}
-    :rm-empty-namespaces {:coerce :boolean :desc "When truthy, also deletes files considered empty"}
     :carve-ignore-file {:coerce :string :desc "The file with ignored vars"}
     :interactive {:coerce :boolean :desc "Interactive mode: ask what to do with an unused var"}
     :dry-run {:coerce :boolean :desc "Dry run "}
     :aggressive {:coerce :boolean :desc "Run carve multiple times to detect transitive unused vars"}
     :out-dir {:coerce :string :desc "Emit transformed code to out-dir instead of overwriting"}
+    :delete-empty-files {:coerce :boolean :desc "When truthy, also deletes files considered empty"}
     :report-format {:coerce :keyword :desc "The report format: :text, :edn or :ignore"}
     :report {:coerce :boolean :desc "Set to true to report and not transform code"}
     :silent {:coerce :boolean :desc "When truthy, does not write to stdout. Implies :interactive false."}

--- a/src/carve/api.clj
+++ b/src/carve/api.clj
@@ -28,6 +28,7 @@
    {:paths {:coerce [] :desc "A list of paths to analyze (files and dirs)"}
     :ignore-vars {:coerce [:symbol] :desc "A list of vars to ignore"}
     :api-namespaces {:coerce [:symbol] :desc "A list of namespaces to ignore"}
+    :rm-empty-namespaces {:coerce :boolean :desc "When truthy, also deletes files considered empty"}
     :carve-ignore-file {:coerce :string :desc "The file with ignored vars"}
     :interactive {:coerce :boolean :desc "Interactive mode: ask what to do with an unused var"}
     :dry-run {:coerce :boolean :desc "Dry run "}

--- a/src/carve/impl.clj
+++ b/src/carve/impl.clj
@@ -195,7 +195,7 @@
   (let [node (z/node zloc)]
     (and (node/symbol-node? node) (= "ns" (node/string node)))))
 
-(defn rm-if-empty!
+(defn delete-if-empty!
   "Deletes a file if it is considered empty."
   [file {:keys [:out-dir :silent] :as _opts}]
   (try
@@ -212,7 +212,7 @@
     (catch Exception e
       (when-not silent
         (binding [*out* *err*]
-          (println (str "Exception thrown when analyzing and/or removing " file "."))
+          (println (str "Exception thrown when analyzing and/or deleting " file "."))
           (println e))))) )
 
 (defn ignore? [api-namespaces {:keys [:ns :export :defined-by :test :private :name]}]
@@ -270,8 +270,8 @@
                 :aggressive
                 :dry-run
                 :report
-                :rm-empty-namespaces
-                :out-dir] :as opts} (sanitize-opts opts)
+                :out-dir
+                :delete-empty-files] :as opts} (sanitize-opts opts)
         ignore (map (fn [ep]
                       [(symbol (namespace ep)) (symbol (name ep))])
                     ignore-vars)
@@ -314,8 +314,8 @@
                                         (group-by :filename))]
                   (doseq [[file vs] data-by-file]
                     (carve! file vs opts)
-                    (when rm-empty-namespaces
-                      (rm-if-empty! file opts)))))
+                    (when delete-empty-files
+                      (delete-if-empty! file opts)))))
               (if aggressive
                 (recur (into removed unused-vars)
                        results

--- a/src/carve/specs.clj
+++ b/src/carve/specs.clj
@@ -4,6 +4,7 @@
 (s/def ::paths (s/coll-of string?))
 (s/def ::ignore-vars (s/coll-of symbol?))
 (s/def ::api-namespaces (s/coll-of symbol?))
+(s/def ::rm-empty-namespaces boolean?)
 (s/def ::carve-ignore-file string?)
 (s/def ::interactive boolean?)
 (s/def ::interactive? boolean?) ;; deprecated
@@ -20,6 +21,7 @@
 (s/def ::opts (s/keys :req-un [::paths]
                       :opt-un [::ignore-vars
                                ::api-namespaces
+                               ::rm-empty-namespaces
                                ::carve-ignore-file
                                ::interactive
                                ::interactive?

--- a/src/carve/specs.clj
+++ b/src/carve/specs.clj
@@ -4,7 +4,6 @@
 (s/def ::paths (s/coll-of string?))
 (s/def ::ignore-vars (s/coll-of symbol?))
 (s/def ::api-namespaces (s/coll-of symbol?))
-(s/def ::rm-empty-namespaces boolean?)
 (s/def ::carve-ignore-file string?)
 (s/def ::interactive boolean?)
 (s/def ::interactive? boolean?) ;; deprecated
@@ -14,6 +13,7 @@
 (s/def ::aggressive boolean?)
 (s/def ::aggressive? boolean?) ;; deprecated
 (s/def ::out-dir string?)
+(s/def ::delete-empty-files boolean?)
 (s/def ::report-format (s/keys :req-un [::format]))
 (s/def ::report (s/or :bool boolean? :map ::report-format))
 (s/def ::silent boolean?)
@@ -21,11 +21,11 @@
 (s/def ::opts (s/keys :req-un [::paths]
                       :opt-un [::ignore-vars
                                ::api-namespaces
-                               ::rm-empty-namespaces
                                ::carve-ignore-file
                                ::interactive
                                ::interactive?
                                ::out-dir
+                               ::delete-empty-files
                                ::dry-run
                                ::dry-run?
                                ::aggressive

--- a/test-resources/delete_empty_files/all_vars_carved+comment_form_left.clj
+++ b/test-resources/delete_empty_files/all_vars_carved+comment_form_left.clj
@@ -1,0 +1,10 @@
+(ns delete-empty-files.all-vars-carved+comment-form-left
+  (:require [clojure.string :refer [split]]))
+
+(defn unused-function []) ;; this one is required for the file to be considered for deletion
+
+(comment
+  "a comment form should not block the file deletion")
+
+(comment
+  "there may be multiple comment forms left in the file")

--- a/test-resources/delete_empty_files/all_vars_carved.clj
+++ b/test-resources/delete_empty_files/all_vars_carved.clj
@@ -1,0 +1,11 @@
+;; comment before other content - should not interfere with deletion
+
+(ns delete-empty-files.all-vars-carved
+  (:require [clojure.string :refer [split]]))
+
+;; at least 1 unused fn is required for the file to be deleted
+
+(defn unused-function [])
+(defn another-unused-function [])
+
+;; comment after other content - should not interfere with deletion

--- a/test-resources/delete_empty_files/no_vars_carved.clj
+++ b/test-resources/delete_empty_files/no_vars_carved.clj
@@ -1,0 +1,7 @@
+(ns delete-empty-files.no-vars-carved
+    (:require [clojure.string :refer [split]]))
+
+(defn used-function []) ;; won't be reported because used by -main
+
+(defn -main []
+      (used-function))

--- a/test/carve/main_test.clj
+++ b/test/carve/main_test.clj
@@ -212,3 +212,26 @@ test-resources/app/app.clj:11:1 app/->unused-arrow-fn
         (spit src-file input)
         (run-main {:paths [src-file] :interactive? false})
         (is (= expected (slurp src-file)))))))
+
+(deftest delete-empty-files-test
+  (testing "when there are no vars to carve, file shouldn't be deleted"
+    (let [tmp-dir (System/getProperty "java.io.tmpdir")]
+      (run-main {:paths              [(.getPath (io/file "test-resources" "delete_empty_files" "no_vars_carved.clj"))]
+                 :interactive        false
+                 :delete-empty-files true
+                 :out-dir            tmp-dir})
+      (is (.exists (io/file tmp-dir "test-resources" "delete_empty_files" "no_vars_carved.clj")))))
+  (testing "when all vars are carved, file gets deleted"
+    (let [tmp-dir (System/getProperty "java.io.tmpdir")]
+      (run-main {:paths              [(.getPath (io/file "test-resources" "delete_empty_files" "all_vars_carved.clj"))]
+                 :interactive        false
+                 :delete-empty-files true
+                 :out-dir            tmp-dir})
+      (is (not (.exists (io/file tmp-dir "test-resources" "delete_empty_files" "all_vars_carved.clj"))))))
+  (testing "when all vars are carved and there is a comment form left, file gets deleted"
+    (let [tmp-dir (System/getProperty "java.io.tmpdir")]
+      (run-main {:paths              [(.getPath (io/file "test-resources" "delete_empty_files" "all_vars_carved+comment_form_left.clj"))]
+                 :interactive        false
+                 :delete-empty-files true
+                 :out-dir            tmp-dir})
+      (is (not (.exists (io/file tmp-dir "test-resources" "delete_empty_files" "all_vars_carved+comment_form_left.clj")))))))


### PR DESCRIPTION
Hi Michiel!

Here's a new option implementation which covers #72. It's called `:delete-empty-files` and for now it will only work for those files that got some of their vars carved. If a namespace was empty, i.e. there were no vars to carve, it shall remain, even if the namespace is itself unused. This is intentional.

There are a few legit cases for having empty namespaces I can think of, e.g. to require other namespaces (a fairly common pattern). And these empty namespaces may also seem unused for whatever quirky reason.

Since it touches way more ground, we can add a feature for deleting files with empty unused namespaces later, if needed. At minimum, it will require us updating the reporting and, most importantly, arranging it's own ignorance support that is to play nicely with existing `.ignore` logic for vars. 

Moreover, this full-fledged empty namespaces carving feature will kinda widen the scope of the tool, which at the moment only removes unused vars. Still, information about unused namespaces is at our fingertips, since `clj-kondo` provides it as well.

```
{:keys [:namespace-definitions :namespace-usages :var-definitions :var-usages]} (:analysis result)
unused-nss (set/difference (set (map :filename namespace-definitions))
                           (set (map :filename namespace-usages)))
```

Anyway, please let me know what you think about the "namespaces carving".