### PR TITLE
More clarity on how the CLI opts interact with the `.carve/config.edn` file

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,12 @@ You may provide options as an EDN literal with `--opts`, e.g.:
 clojure -M:carve --opts '{:paths ["src" "test"] :report {:format :text}}'
 ```
 
+To also load the config file in `.carve/config.edn` when passing `--opts`, set `:merge-config`:
+
+```shell
+clojure -M:carve --opts '{:interactive true :merge-config true}'
+```
+
 #### Clojure tool
 
 As a [clojure tool](https://clojure.org/reference/deps_and_cli#_tool_usage):
@@ -110,7 +116,8 @@ Run `carve --help` to see options.
 You can also store the config for your project in `.carve/config.edn`. When
 invoking carve with no options, the options in `.carve/config.edn` will be used.
 When providing options, the CLI options will take precedence over the configuration
-in`.carve/config.edn`.
+in `.carve/config.edn` and the file will be ignored. Pass `:merge-config` from the 
+CLI to also load and merge `.carve/config.edn`.
 
 All options:
 
@@ -122,6 +129,7 @@ All options:
   by default.
 - `:interactive`: ask what to do with an unused var: remove from the file, add
   to `.carve/ignore` or continue. Set to `true` by default.
+- `:merge-config`: Merge the CLI options and the config file together. Default is false.
 - `:out-dir`: instead of writing back to the original file, write to this dir.
 - `:dry-run`: just print the unused var expression.
 - `:aggressive`: runs multiple times until no unused vars are left. Defaults to `false`.

--- a/src/carve/api.clj
+++ b/src/carve/api.clj
@@ -51,9 +51,7 @@
   {:org.babashka/cli cli-opts}
   [opts] ;; to validate opts with spec, load carve.specs
   (let [opts (or (:opts opts) opts)
-        config-file (io/file ".carve/config.edn")
-        config (when (.exists config-file)
-                 (edn/read-string (slurp config-file)))]
+        config (impl/load-config-file)]
     (if (and (empty? opts) (not config))
       (binding [*err* *out*]
         (print-help)
@@ -61,7 +59,7 @@
       (if (:help opts)
         (do (print-help)
             {:exit-code 0})
-        (let [{:keys [:report :config]} (impl/run+ opts)
+        (let [{:keys [:report :config]} (impl/run+ opts) ;; run+ will also call (impl/load-config-file)
                 format (or (:report-format opts)
                            (-> config :report :format))]
             (when (:report config)

--- a/src/carve/impl.clj
+++ b/src/carve/impl.clj
@@ -306,7 +306,9 @@
     (throw (ex-info "Path not found" {:paths paths}))))
 
 (defn load-opts
-  "Load options, giving higher precedence to options passed from the CLI"
+  "Load options, giving higher precedence to options passed from the CLI.
+
+  If :merge-config is set from the CLI, also merge in the config file."
   [config opts]
   (let [opts (if (:merge-config opts)
                (if config (merge config opts)
@@ -315,12 +317,16 @@
     (validate-opts! opts)
     opts))
 
+(defn load-config-file
+  []
+  (let [config-file (io/file ".carve/config.edn")]
+    (when (.exists config-file)
+      (edn/read-string (slurp config-file)))))
+
 (defn run+
   ([] (run+ nil))
   ([opts]
-   (let [config-file (io/file ".carve/config.edn")
-         config (when (.exists config-file)
-                  (edn/read-string (slurp config-file)))
+   (let [config (load-config-file)
          opts (load-opts config opts)
          report (do-run! opts)]
      {:report report


### PR DESCRIPTION
- Document `:merge-config` and how it interacts with `.carve/config.edn`
- Extract duplicated `impl/load-config-file`

Related to https://github.com/borkdude/carve/issues/42

Is `:merge-config` the right config key? Maybe `:merge-config-file` instead?